### PR TITLE
Accept repeated requests

### DIFF
--- a/bin/acceptance-test
+++ b/bin/acceptance-test
@@ -21,3 +21,4 @@ else
   echo "Could not connect to the server" >&2
   exit 1
 fi
+

--- a/src/main/java/echoServer/EchoServer.java
+++ b/src/main/java/echoServer/EchoServer.java
@@ -1,21 +1,25 @@
 package echoServer;
 
-import java.io.IOException;
-
 public class EchoServer {
 
     private final PortListenable portListener;
+    private final Loopable looper;
 
-    public EchoServer(PortListenable portListener) {
+    public EchoServer(PortListenable portListener, Loopable looper) {
         this.portListener = portListener;
+        this.looper = looper;
     }
 
-    public void serve() throws IOException {
-        ReadableWriteable socketReaderWriter = portListener.listen();
+    public void serve() throws Exception {
+        looper.loop(() -> {
+            ReadableWriteable socketReaderWriter = portListener.listen();
 
-        String message;
-        while ((message = socketReaderWriter.readLine()) != null) {
-            socketReaderWriter.writeLine(message);
-        }
+            String message;
+            while ((message = socketReaderWriter.readLine()) != null) {
+                socketReaderWriter.writeLine(message);
+            }
+
+            socketReaderWriter.close();
+        });
     }
 }

--- a/src/main/java/echoServer/EchoServer.java
+++ b/src/main/java/echoServer/EchoServer.java
@@ -12,14 +12,13 @@ public class EchoServer {
 
     public void serve() throws Exception {
         looper.loop(() -> {
-            ReadableWriteable socketReaderWriter = portListener.listen();
+            try (ReadableWriteable socketReaderWriter = portListener.listen()) {
 
-            String message;
-            while ((message = socketReaderWriter.readLine()) != null) {
-                socketReaderWriter.writeLine(message);
+                String message;
+                while ((message = socketReaderWriter.readLine()) != null) {
+                    socketReaderWriter.writeLine(message);
+                }
             }
-
-            socketReaderWriter.close();
         });
     }
 }

--- a/src/main/java/echoServer/Loopable.java
+++ b/src/main/java/echoServer/Loopable.java
@@ -1,0 +1,10 @@
+package echoServer;
+
+public interface Loopable {
+    void loop(Block block) throws Exception;
+
+    interface Block {
+        void call() throws Exception;
+    }
+}
+

--- a/src/main/java/echoServer/Main.java
+++ b/src/main/java/echoServer/Main.java
@@ -7,14 +7,15 @@ import java.net.ServerSocket;
  */
 public class Main {
     public static void main(String[] args) throws Exception {
-        ServerSocket serverSocket = new ServerSocket(3000);
-        PortListenable portListener = new PortListener(serverSocket);
-        Loopable infiniteLooper = block -> {
-            while (true) {
-                block.call();
-            }
-        };
+        try (ServerSocket serverSocket = new ServerSocket(3000)) {
+            PortListenable portListener = new PortListener(serverSocket);
+            Loopable infiniteLooper = block -> {
+                while (true) {
+                    block.call();
+                }
+            };
 
-        new EchoServer(portListener, infiniteLooper).serve();
+            new EchoServer(portListener, infiniteLooper).serve();
+        }
     }
 }

--- a/src/main/java/echoServer/Main.java
+++ b/src/main/java/echoServer/Main.java
@@ -1,15 +1,20 @@
 package echoServer;
 
-import java.io.IOException;
 import java.net.ServerSocket;
 
 /**
  * echoServer.Main runs the server.
  */
 public class Main {
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws Exception {
         ServerSocket serverSocket = new ServerSocket(3000);
         PortListenable portListener = new PortListener(serverSocket);
-        new EchoServer(portListener).serve();
+        Loopable infiniteLooper = block -> {
+            while (true) {
+                block.call();
+            }
+        };
+
+        new EchoServer(portListener, infiniteLooper).serve();
     }
 }

--- a/src/main/java/echoServer/ReadableWriteable.java
+++ b/src/main/java/echoServer/ReadableWriteable.java
@@ -2,10 +2,8 @@ package echoServer;
 
 import java.io.IOException;
 
-public interface ReadableWriteable {
+public interface ReadableWriteable extends AutoCloseable {
     String readLine() throws IOException;
 
     void writeLine(String message) throws IOException;
-
-    void close() throws IOException;
 }

--- a/src/main/java/echoServer/ReadableWriteable.java
+++ b/src/main/java/echoServer/ReadableWriteable.java
@@ -6,4 +6,6 @@ public interface ReadableWriteable {
     String readLine() throws IOException;
 
     void writeLine(String message) throws IOException;
+
+    void close() throws IOException;
 }

--- a/src/main/java/echoServer/SocketReaderWriter.java
+++ b/src/main/java/echoServer/SocketReaderWriter.java
@@ -31,7 +31,6 @@ public class SocketReaderWriter implements ReadableWriteable {
 
     @Override
     public void close() throws IOException {
-        reader.close();
-        writer.close();
+        socket.close();
     }
 }

--- a/src/main/java/echoServer/SocketReaderWriter.java
+++ b/src/main/java/echoServer/SocketReaderWriter.java
@@ -8,22 +8,30 @@ import java.net.Socket;
 
 public class SocketReaderWriter implements ReadableWriteable {
     private final Socket socket;
+    private final BufferedReader reader;
+    private final PrintWriter writer;
 
-    public SocketReaderWriter(Socket socket) {
+    public SocketReaderWriter(Socket socket) throws IOException {
         this.socket = socket;
+        this.reader = new BufferedReader(
+                new InputStreamReader(this.socket.getInputStream())
+        );
+        this.writer = new PrintWriter(socket.getOutputStream(), true);
     }
 
     @Override
     public String readLine() throws IOException {
-        BufferedReader reader = new BufferedReader(
-                new InputStreamReader(this.socket.getInputStream())
-        );
         return reader.readLine();
     }
 
     @Override
     public void writeLine(String message) throws IOException {
-        PrintWriter writer = new PrintWriter(socket.getOutputStream(), true);
         writer.println(message);
+    }
+
+    @Override
+    public void close() throws IOException {
+        reader.close();
+        writer.close();
     }
 }

--- a/src/test/java/echoServer/EchoServerTest.java
+++ b/src/test/java/echoServer/EchoServerTest.java
@@ -36,17 +36,17 @@ public class EchoServerTest {
     }
 
     @Test
-    public void closesIOStreamsAfterDisconnecting() throws Exception {
+    public void closesReadableWriteable() throws Exception {
         TestReaderWriter testReaderWriter = new TestReaderWriter()
                 .send("text sent when connection is open\n")
-                .closeConnection();
+                .disconnect();
 
         TestListener testListener = new TestListener(testReaderWriter);
         Loopable looper = new DoItOnce();
         new EchoServer(testListener, looper).serve();
 
         assertEquals(List.of(
-                        "Closed ReadableWriteable IO streams"),
+                        "Closed ReadableWriteable"),
                 testReaderWriter.events());
     }
 
@@ -54,7 +54,7 @@ public class EchoServerTest {
     public void itAcceptsRepeatedConnections() throws Exception {
         TestReaderWriter testReaderWriter = new TestReaderWriter()
                 .send("text sent over first connection\n")
-                .closeConnection()
+                .disconnect()
                 .send("text sent over second connection \n");
 
         TestListener testListener = new TestListener(testReaderWriter);
@@ -103,10 +103,10 @@ public class EchoServerTest {
 
         @Override
         public void close() {
-            events.add("Closed ReadableWriteable IO streams");
+            events.add("Closed ReadableWriteable");
         }
 
-        public TestReaderWriter closeConnection() {
+        public TestReaderWriter disconnect() {
             return this.send(null);
         }
     }

--- a/src/test/java/echoServer/SocketReaderWriterTest.java
+++ b/src/test/java/echoServer/SocketReaderWriterTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class SocketReaderWriterTest {
 
@@ -28,5 +29,20 @@ public class SocketReaderWriterTest {
         String output = testSocket.output();
 
         assertEquals("Hello\n", output);
+    }
+
+    @Test
+    void itCloses() throws IOException {
+        TestSocket testSocket = new TestSocket("Hello\n");
+        ReadableWriteable socketReaderWriter = new SocketReaderWriter(testSocket);
+
+        socketReaderWriter.readLine();
+        socketReaderWriter.writeLine("Hello");
+
+        socketReaderWriter.close();
+
+        assertThrows(IOException.class, () -> {
+            socketReaderWriter.readLine();
+        });
     }
 }

--- a/src/test/java/echoServer/SocketReaderWriterTest.java
+++ b/src/test/java/echoServer/SocketReaderWriterTest.java
@@ -3,9 +3,9 @@ package echoServer;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class SocketReaderWriterTest {
 
@@ -32,17 +32,32 @@ public class SocketReaderWriterTest {
     }
 
     @Test
-    void itCloses() throws IOException {
-        TestSocket testSocket = new TestSocket("Hello\n");
+    void createsOnlyOneReaderAndOneWriter() throws IOException {
+        TestSocket testSocket = new TestSocket("First input line\nSecond input line\n");
         ReadableWriteable socketReaderWriter = new SocketReaderWriter(testSocket);
 
         socketReaderWriter.readLine();
-        socketReaderWriter.writeLine("Hello");
+        socketReaderWriter.readLine();
+        socketReaderWriter.writeLine("");
+        socketReaderWriter.writeLine("");
+
+        assertEquals(List.of(
+                "A new reader accessed the input stream",
+                "A new writer accessed the output stream"
+        ), testSocket.events());
+    }
+
+    @Test
+    void closesTheConnection() throws Exception {
+        TestSocket testSocket = new TestSocket("Hello\n");
+        ReadableWriteable socketReaderWriter = new SocketReaderWriter(testSocket);
 
         socketReaderWriter.close();
 
-        assertThrows(IOException.class, () -> {
-            socketReaderWriter.readLine();
-        });
+        assertEquals(List.of(
+                "A new reader accessed the input stream",
+                "A new writer accessed the output stream",
+                "The socket has been closed"
+        ), testSocket.events());
     }
 }

--- a/src/test/java/echoServer/TestSocket.java
+++ b/src/test/java/echoServer/TestSocket.java
@@ -5,11 +5,15 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
+import java.util.ArrayList;
+import java.util.List;
 
 class TestSocket extends Socket {
 
     private final String inputString;
+    private final List<String> events = new ArrayList<>();
     private ByteArrayOutputStream outputStream;
+    private ByteArrayInputStream inputStream;
 
     public TestSocket(String inputString) {
         this.inputString = inputString;
@@ -17,16 +21,27 @@ class TestSocket extends Socket {
 
     @Override
     public InputStream getInputStream() {
-        return new ByteArrayInputStream(inputString.getBytes());
+        this.events.add("A new reader accessed the input stream");
+        inputStream = new ByteArrayInputStream(inputString.getBytes());
+        return inputStream;
     }
 
     @Override
     public OutputStream getOutputStream() {
+        events.add("A new writer accessed the output stream");
         outputStream = new ByteArrayOutputStream();
         return outputStream;
     }
 
     public String output() {
         return outputStream.toString();
+    }
+
+    public void close() {
+        events.add("The socket has been closed");
+    }
+
+    public List<String> events() {
+        return events;
     }
 }


### PR DESCRIPTION
**Additions in this request:**
- A user can connect to the server.
- A user can connect again after the first connection is disconnected.
- The IO streams are closed after a client disconnects to release system resources.
- **Bug fix**: the `SocketReaderWriter` was creating a new `BufferedReader` and `PrintWriter` each time `readLine`() or `writeLine`() was called. Now, just one `BufferedReader` and one `BufferedWriter` are created per connection. 

In order to make the infinite loop testable, it was extracted into a `Loopable` interface. The interface defines a single method, `loop`, which takes in a block and executes it any number of times. 

I'm planning to add higher-level tests in a separate PR. 