### PR TITLE
Only deploy on merge

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -4,7 +4,6 @@ on:
     branches: [ "**" ]
   pull_request:
     branches: [ "**" ]
-
 permissions:
   contents: read
 
@@ -56,6 +55,7 @@ jobs:
 
   deploy:
     name: deploy
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     needs: build-and-test
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -2,8 +2,6 @@ name: Java CI with Gradle
 on:
   push:
     branches: [ "**" ]
-  pull_request:
-    branches: [ "**" ]
 permissions:
   contents: read
 


### PR DESCRIPTION
Changes in this request:

- Added a conditional to the Deploy job so it's only triggered on a push to the main branch, rather than on a push to any branch.
- Removed the Pull Request workflow trigger since the workflow was running twice when a pull request was opened. 