### PR TITLE
Simple get

### DIFF
--- a/src/main/java/server/HTTPServer.java
+++ b/src/main/java/server/HTTPServer.java
@@ -3,9 +3,10 @@ package server;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class HTTPServer implements Application {
-    private final List<String> paths = List.of("/");
+    private final List<String> paths = List.of("/", "/simple_get", "/simple_get_with_body");
 
     @Override
     public void call(ReadableWriteable readerWriter) throws IOException {
@@ -29,9 +30,13 @@ public class HTTPServer implements Application {
 
     private void writeResponse(String path, ReadableWriteable readerWriter) throws IOException {
         if (paths.contains(path)) {
-            readerWriter.writeLine("HTTP/1.1 200 OK\r\nContent-Length:0\r\n");
+            if (Objects.equals(path, "/simple_get_with_body")) {
+                readerWriter.writeLine("HTTP/1.1 200 OK\r\nContent-Length:11\r\n\nHello world");
+            } else {
+                readerWriter.writeLine("HTTP/1.1 200 OK\r\nContent-Length:0\r\n\n");
+            }
         } else {
-            readerWriter.writeLine("HTTP/1.1 404 Not Found\r\nContent-Length:0\r\n");
+            readerWriter.writeLine("HTTP/1.1 404 Not Found\r\nContent-Length:0\r\n\n");
         }
     }
 }

--- a/src/main/java/server/HTTPServer.java
+++ b/src/main/java/server/HTTPServer.java
@@ -26,20 +26,21 @@ public class HTTPServer implements Application {
     }
 
     private void writeResponse(String path, ReadableWriteable readerWriter) throws IOException {
-        Response response;
+        Response response = route(path);
+        readerWriter.writeLine(response.toString());
+    }
 
+    private Response route(String path) {
         switch (path) {
             case "/simple_get_with_body" -> {
-                response = new Response("200 OK", "Content-Length:11", "Hello world");
+                return new Response("200 OK", "Content-Length:11", "Hello world");
             }
             case "/simple_get", "/" -> {
-                response = new Response("200 OK", "Content-Length:0", "");
+                return new Response("200 OK", "Content-Length:0", "");
             }
             default -> {
-                response = new Response("404 Not Found", "Content-Length:0", "");
+                return new Response("404 Not Found", "Content-Length:0", "");
             }
         }
-
-        readerWriter.writeLine(response.toString());
     }
 }

--- a/src/main/java/server/HTTPServer.java
+++ b/src/main/java/server/HTTPServer.java
@@ -5,6 +5,12 @@ import java.util.ArrayList;
 
 public class HTTPServer implements Application {
 
+    private final String protocol;
+
+    public HTTPServer() {
+        this.protocol = "HTTP/1.1";
+    }
+
     @Override
     public void call(ReadableWriteable readerWriter) throws IOException {
         ArrayList<String> request = readRequest(readerWriter);
@@ -27,20 +33,24 @@ public class HTTPServer implements Application {
 
     private void writeResponse(String path, ReadableWriteable readerWriter) throws IOException {
         Response response = route(path);
-        readerWriter.writeLine(response.toString());
+        readerWriter.writeLine(format(response));
     }
 
     private Response route(String path) {
         switch (path) {
             case "/simple_get_with_body" -> {
-                return new Response("200 OK", "Content-Length:11", "Hello world");
+                return new Response(this.protocol, "200 OK", "Content-Length:11", "Hello world");
             }
             case "/simple_get", "/" -> {
-                return new Response("200 OK", "Content-Length:0", "");
+                return new Response(this.protocol, "200 OK", "Content-Length:0", "");
             }
             default -> {
-                return new Response("404 Not Found", "Content-Length:0", "");
+                return new Response(this.protocol, "404 Not Found", "Content-Length:0", "");
             }
         }
+    }
+
+    private String format(Response response) {
+        return response.getProtocol() + " " + response.getStatusCode() + "\r\n" + response.getHeaders() + "\r\n" + "\n" + response.getBody();
     }
 }

--- a/src/main/java/server/HTTPServer.java
+++ b/src/main/java/server/HTTPServer.java
@@ -2,11 +2,8 @@ package server;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
 
 public class HTTPServer implements Application {
-    private final List<String> paths = List.of("/", "/simple_get", "/simple_get_with_body");
 
     @Override
     public void call(ReadableWriteable readerWriter) throws IOException {
@@ -29,14 +26,20 @@ public class HTTPServer implements Application {
     }
 
     private void writeResponse(String path, ReadableWriteable readerWriter) throws IOException {
-        if (paths.contains(path)) {
-            if (Objects.equals(path, "/simple_get_with_body")) {
-                readerWriter.writeLine("HTTP/1.1 200 OK\r\nContent-Length:11\r\n\nHello world");
-            } else {
-                readerWriter.writeLine("HTTP/1.1 200 OK\r\nContent-Length:0\r\n\n");
+        Response response;
+
+        switch (path) {
+            case "/simple_get_with_body" -> {
+                response = new Response("200 OK", "Content-Length:11", "Hello world");
             }
-        } else {
-            readerWriter.writeLine("HTTP/1.1 404 Not Found\r\nContent-Length:0\r\n\n");
+            case "/simple_get", "/" -> {
+                response = new Response("200 OK", "Content-Length:0", "");
+            }
+            default -> {
+                response = new Response("404 Not Found", "Content-Length:0", "");
+            }
         }
+
+        readerWriter.writeLine(response.toString());
     }
 }

--- a/src/main/java/server/HTTPServer.java
+++ b/src/main/java/server/HTTPServer.java
@@ -16,7 +16,7 @@ public class HTTPServer implements Application {
         ArrayList<String> request = readRequest(readerWriter);
         String path = getPath(request);
         Response response = route(path);
-        readerWriter.writeLine(format(response));
+        response.write(readerWriter);
     }
 
     private ArrayList<String> readRequest(ReadableWriteable readerWriter) throws IOException {
@@ -45,8 +45,5 @@ public class HTTPServer implements Application {
             }
         }
     }
-
-    private String format(Response response) {
-        return response.getProtocol() + " " + response.getStatusCode() + "\r\n" + response.getHeaders() + "\r\n" + "\n" + response.getBody();
-    }
+    
 }

--- a/src/main/java/server/HTTPServer.java
+++ b/src/main/java/server/HTTPServer.java
@@ -15,7 +15,8 @@ public class HTTPServer implements Application {
     public void call(ReadableWriteable readerWriter) throws IOException {
         ArrayList<String> request = readRequest(readerWriter);
         String path = getPath(request);
-        writeResponse(path, readerWriter);
+        Response response = route(path);
+        readerWriter.writeLine(format(response));
     }
 
     private ArrayList<String> readRequest(ReadableWriteable readerWriter) throws IOException {
@@ -29,11 +30,6 @@ public class HTTPServer implements Application {
 
     private String getPath(ArrayList<String> request) {
         return request.get(0).split("\\s+")[1];
-    }
-
-    private void writeResponse(String path, ReadableWriteable readerWriter) throws IOException {
-        Response response = route(path);
-        readerWriter.writeLine(format(response));
     }
 
     private Response route(String path) {

--- a/src/main/java/server/Response.java
+++ b/src/main/java/server/Response.java
@@ -1,0 +1,25 @@
+package server;
+
+public class Response {
+    private final String protocol;
+    private final String statusCode;
+    private final String headers;
+    private final String body;
+    private final String responseString;
+
+    public Response(String statusCode, String headers, String body) {
+        this.protocol = "HTTP/1.1";
+        this.statusCode = statusCode;
+        this.headers = headers;
+        this.body = body;
+        this.responseString = createResponseString();
+    }
+
+    public String toString() {
+        return this.responseString;
+    }
+
+    private String createResponseString() {
+        return protocol + " " + statusCode + "\r\n" + headers + "\r\n" + "\n" + body;
+    }
+}

--- a/src/main/java/server/Response.java
+++ b/src/main/java/server/Response.java
@@ -5,21 +5,27 @@ public class Response {
     private final String statusCode;
     private final String headers;
     private final String body;
-    private final String responseString;
 
-    public Response(String statusCode, String headers, String body) {
-        this.protocol = "HTTP/1.1";
+    public Response(String protocol, String statusCode, String headers, String body) {
+        this.protocol = protocol;
         this.statusCode = statusCode;
         this.headers = headers;
         this.body = body;
-        this.responseString = createResponseString();
     }
 
-    public String toString() {
-        return this.responseString;
+    public String getProtocol() {
+        return protocol;
     }
 
-    private String createResponseString() {
-        return protocol + " " + statusCode + "\r\n" + headers + "\r\n" + "\n" + body;
+    public String getStatusCode() {
+        return statusCode;
+    }
+
+    public String getHeaders() {
+        return headers;
+    }
+
+    public String getBody() {
+        return body;
     }
 }

--- a/src/main/java/server/Response.java
+++ b/src/main/java/server/Response.java
@@ -1,5 +1,7 @@
 package server;
 
+import java.io.IOException;
+
 public class Response {
     private final String protocol;
     private final String statusCode;
@@ -13,19 +15,11 @@ public class Response {
         this.body = body;
     }
 
-    public String getProtocol() {
-        return protocol;
+    public void write(ReadableWriteable readerWriter) throws IOException {
+        readerWriter.writeLine(responseString());
     }
 
-    public String getStatusCode() {
-        return statusCode;
-    }
-
-    public String getHeaders() {
-        return headers;
-    }
-
-    public String getBody() {
-        return body;
+    private String responseString() {
+        return this.protocol + " " + this.statusCode + "\r\n" + this.headers + "\r\n" + "\n" + this.body;
     }
 }

--- a/src/main/java/server/SocketReaderWriter.java
+++ b/src/main/java/server/SocketReaderWriter.java
@@ -25,8 +25,9 @@ public class SocketReaderWriter implements ReadableWriteable {
     }
 
     @Override
-    public void writeLine(String message) throws IOException {
-        writer.println(message);
+    public void writeLine(String message) {
+        writer.print(message);
+        writer.flush();
     }
 
     @Override

--- a/src/test/java/server/HTTPServerTest.java
+++ b/src/test/java/server/HTTPServerTest.java
@@ -17,8 +17,35 @@ public class HTTPServerTest {
 
         new HTTPServer().call(testReaderWriter);
 
-        assertEquals(List.of("HTTP/1.1 200 OK\r\nContent-Length:0\r\n"),
-                testReaderWriter.received());
+        assertEquals(List.of(
+                "HTTP/1.1 200 OK\r\nContent-Length:0\r\n\n"
+        ), testReaderWriter.received());
+    }
+
+    @Test
+    void itReturns200OKForSimpleGet() throws IOException {
+        String testRequest = "GET /simple_get HTTP/1.1\r\nContent-Length:0\r\n";
+        TestReaderWriter testReaderWriter = new TestReaderWriter()
+                .send(testRequest);
+
+        new HTTPServer().call(testReaderWriter);
+
+        assertEquals(List.of(
+                "HTTP/1.1 200 OK\r\nContent-Length:0\r\n\n"
+        ), testReaderWriter.received());
+    }
+
+    @Test
+    void itReturns200OKHelloWorldForSimpleGetWithBody() throws IOException {
+        String testRequest = "GET /simple_get_with_body HTTP/1.1\r\nContent-Length:0\r\n";
+        TestReaderWriter testReaderWriter = new TestReaderWriter()
+                .send(testRequest);
+
+        new HTTPServer().call(testReaderWriter);
+
+        assertEquals(List.of(
+                "HTTP/1.1 200 OK\r\nContent-Length:11\r\n\nHello world"
+        ), testReaderWriter.received());
     }
 
     @Test
@@ -29,8 +56,9 @@ public class HTTPServerTest {
 
         new HTTPServer().call(testReaderWriter);
 
-        assertEquals(List.of("HTTP/1.1 404 Not Found\r\nContent-Length:0\r\n"),
-                testReaderWriter.received());
+        assertEquals(List.of(
+                "HTTP/1.1 404 Not Found\r\nContent-Length:0\r\n\n"
+        ), testReaderWriter.received());
     }
 
     @Test
@@ -46,8 +74,8 @@ public class HTTPServerTest {
         httpServer.call(testReaderWriter);
 
         assertEquals(List.of(
-                        "HTTP/1.1 200 OK\r\nContent-Length:0\r\n",
-                        "HTTP/1.1 404 Not Found\r\nContent-Length:0\r\n"),
-                testReaderWriter.received());
+                "HTTP/1.1 200 OK\r\nContent-Length:0\r\n\n",
+                "HTTP/1.1 404 Not Found\r\nContent-Length:0\r\n\n"
+        ), testReaderWriter.received());
     }
 }

--- a/src/test/java/server/ResponseTest.java
+++ b/src/test/java/server/ResponseTest.java
@@ -2,17 +2,31 @@ package server;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ResponseTest {
 
     @Test
-    void itHasAllNecessaryFields() {
+    void itWritesAFormattedResponseWithNoBody() throws IOException {
+        TestReaderWriter testReaderWriter = new TestReaderWriter();
+        Response response = new Response("HTTP/1.1", "200 OK", "Content-Length:0", "");
+
+        response.write(testReaderWriter);
+
+        assertEquals(List.of("HTTP/1.1 200 OK\r\nContent-Length:0\r\n\n"), testReaderWriter.received());
+    }
+
+    @Test
+    void itWritesAFormattedResponseWithABody() throws IOException {
+        TestReaderWriter testReaderWriter = new TestReaderWriter();
         Response response = new Response("HTTP/1.1", "200 OK", "Content-Length:11", "Hello world");
 
-        assertEquals("HTTP/1.1", response.getProtocol());
-        assertEquals("200 OK", response.getStatusCode());
-        assertEquals("Content-Length:11", response.getHeaders());
-        assertEquals("Hello world", response.getBody());
+        response.write(testReaderWriter);
+
+        assertEquals(List.of("HTTP/1.1 200 OK\r\nContent-Length:11\r\n\nHello world"), testReaderWriter.received());
     }
+    
 }

--- a/src/test/java/server/ResponseTest.java
+++ b/src/test/java/server/ResponseTest.java
@@ -1,0 +1,22 @@
+package server;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ResponseTest {
+
+    @Test
+    void itConstructsAResponseStringWithNoBody() {
+        Response response = new Response("200 OK", "Content-Length:0", "");
+
+        assertEquals("HTTP/1.1 200 OK\r\nContent-Length:0\r\n\n", response.toString());
+    }
+
+    @Test
+    void itConstructsAResponseStringWithABody() {
+        Response response = new Response("200 OK", "Content-Length:11", "Hello world");
+
+        assertEquals("HTTP/1.1 200 OK\r\nContent-Length:11\r\n\nHello world", response.toString());
+    }
+}

--- a/src/test/java/server/ResponseTest.java
+++ b/src/test/java/server/ResponseTest.java
@@ -7,16 +7,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class ResponseTest {
 
     @Test
-    void itConstructsAResponseStringWithNoBody() {
-        Response response = new Response("200 OK", "Content-Length:0", "");
+    void itHasAllNecessaryFields() {
+        Response response = new Response("HTTP/1.1", "200 OK", "Content-Length:11", "Hello world");
 
-        assertEquals("HTTP/1.1 200 OK\r\nContent-Length:0\r\n\n", response.toString());
-    }
-
-    @Test
-    void itConstructsAResponseStringWithABody() {
-        Response response = new Response("200 OK", "Content-Length:11", "Hello world");
-
-        assertEquals("HTTP/1.1 200 OK\r\nContent-Length:11\r\n\nHello world", response.toString());
+        assertEquals("HTTP/1.1", response.getProtocol());
+        assertEquals("200 OK", response.getStatusCode());
+        assertEquals("Content-Length:11", response.getHeaders());
+        assertEquals("Hello world", response.getBody());
     }
 }

--- a/src/test/java/server/SocketReaderWriterTest.java
+++ b/src/test/java/server/SocketReaderWriterTest.java
@@ -28,7 +28,7 @@ public class SocketReaderWriterTest {
 
         String output = testSocket.output();
 
-        assertEquals("Hello\n", output);
+        assertEquals("Hello", output);
     }
 
     @Test


### PR DESCRIPTION
Changes in this request: 

- Hard-coded responses for `simple_get` and `simple_get_with_body`
- Extracted a `Response` class that manages the response formatting
- Fixed syntax errors:
      - extra `\n` required between response `headers` and `body`
      - no extra `\n` allowed at the end of the response

I plan to extract a `Routes` class in the next PR. 