### PR TITLE
Simple post

### DIFF
--- a/src/main/java/server/BodyParser.java
+++ b/src/main/java/server/BodyParser.java
@@ -3,12 +3,7 @@ package server;
 import java.io.IOException;
 
 public class BodyParser {
-
     public String parse(ReadableWriteable readerWriter, int contentLength) throws IOException {
-        String body = "";
-        while (body.length() < contentLength) {
-            body += readerWriter.readLine();
-        }
-        return body;
+        return readerWriter.read(contentLength);
     }
 }

--- a/src/main/java/server/BodyParser.java
+++ b/src/main/java/server/BodyParser.java
@@ -1,0 +1,14 @@
+package server;
+
+import java.io.IOException;
+
+public class BodyParser {
+
+    public String parse(ReadableWriteable readerWriter, int contentLength) throws IOException {
+        String body = "";
+        while (body.length() < contentLength) {
+            body += readerWriter.readLine();
+        }
+        return body;
+    }
+}

--- a/src/main/java/server/ContentLengthParser.java
+++ b/src/main/java/server/ContentLengthParser.java
@@ -1,0 +1,12 @@
+package server;
+
+import java.util.Map;
+
+public class ContentLengthParser {
+    public int parse(Map<String, String> headers) {
+        if (headers.containsKey("content-length")) {
+            return Integer.parseInt(headers.get("content-length"));
+        }
+        return -1;
+    }
+}

--- a/src/main/java/server/HTTPServerMain.java
+++ b/src/main/java/server/HTTPServerMain.java
@@ -16,7 +16,12 @@ public class HTTPServerMain {
                 }
             };
 
-            RequestParser requestParser = new RequestParser(new RequestLineParser(), new HeadersParser());
+            RequestParser requestParser = new RequestParser(
+                    new RequestLineParser(),
+                    new HeadersParser(),
+                    new ContentLengthParser(),
+                    new BodyParser()
+            );
             Handler router = HTTPServerSpecRouterFactory.create();
             ResponseWriteable responseWriter = new ResponseWriter();
 

--- a/src/main/java/server/HTTPServerSpecRouterFactory.java
+++ b/src/main/java/server/HTTPServerSpecRouterFactory.java
@@ -9,7 +9,8 @@ public class HTTPServerSpecRouterFactory {
             "HEAD /simple_get", new SimpleGetHandler(),
             "GET /simple_get_with_body", new SimpleGetWithBodyHandler(),
             "HEAD /head_request", new HeadRequestHandler(),
-            "GET /redirect", new RedirectHandler()
+            "GET /redirect", new RedirectHandler(),
+            "POST /echo_body", new SimplePostHandler()
     );
 
     public static Router create() {

--- a/src/main/java/server/HeadRequestHandler.java
+++ b/src/main/java/server/HeadRequestHandler.java
@@ -1,12 +1,14 @@
 package server;
 
+import java.util.Map;
+
 public class HeadRequestHandler implements Handler {
     @Override
     public Response call(Request request) {
         return new Response(
                 "HTTP/1.1",
                 "200 OK",
-                "Content-Length:0",
+                Map.of("Content-Length", "0"),
                 ""
         );
     }

--- a/src/main/java/server/HeadersParser.java
+++ b/src/main/java/server/HeadersParser.java
@@ -31,8 +31,8 @@ public class HeadersParser {
 
     private Header parseHeader(String header) {
         List<String> parsedHeader = Arrays.asList(header.split(":"));
-        String key = parsedHeader.get(0).trim();
-        String value = parsedHeader.get(1).trim();
+        String key = parsedHeader.get(0).trim().toLowerCase();
+        String value = parsedHeader.get(1).trim().toLowerCase();
 
         return new Header(key, value);
     }

--- a/src/main/java/server/NotFoundHandler.java
+++ b/src/main/java/server/NotFoundHandler.java
@@ -1,5 +1,7 @@
 package server;
 
+import java.util.Map;
+
 public class NotFoundHandler implements Handler {
 
     @Override
@@ -7,7 +9,7 @@ public class NotFoundHandler implements Handler {
         return new Response(
                 "HTTP/1.1",
                 "404 Not Found",
-                "Content-Length:0",
+                Map.of("Content-Length", "0"),
                 ""
         );
     }

--- a/src/main/java/server/ReadableWriteable.java
+++ b/src/main/java/server/ReadableWriteable.java
@@ -3,6 +3,8 @@ package server;
 import java.io.IOException;
 
 public interface ReadableWriteable extends AutoCloseable {
+    String read(int contentLength) throws IOException;
+
     String readLine() throws IOException;
 
     void writeLine(String message);

--- a/src/main/java/server/ReadableWriteable.java
+++ b/src/main/java/server/ReadableWriteable.java
@@ -6,5 +6,4 @@ public interface ReadableWriteable extends AutoCloseable {
     String readLine() throws IOException;
 
     void writeLine(String message);
-
 }

--- a/src/main/java/server/RedirectHandler.java
+++ b/src/main/java/server/RedirectHandler.java
@@ -1,12 +1,14 @@
 package server;
 
+import java.util.Map;
+
 public class RedirectHandler implements Handler {
     @Override
     public Response call(Request request) {
         return new Response(
                 "HTTP/1.1",
                 "301 Moved Permanently",
-                "Location: http://127.0.0.1:5000/simple_get",
+                Map.of("Location", "http://127.0.0.1:5000/simple_get"),
                 ""
         );
     }

--- a/src/main/java/server/Request.java
+++ b/src/main/java/server/Request.java
@@ -2,5 +2,5 @@ package server;
 
 import java.util.Map;
 
-public record Request(String method, String path, Map<String, String> headers) {
+public record Request(String method, String path, Map<String, String> headers, String body) {
 }

--- a/src/main/java/server/RequestLineParser.java
+++ b/src/main/java/server/RequestLineParser.java
@@ -8,7 +8,6 @@ public class RequestLineParser {
 
     public RequestLine parse(ReadableWriteable readableWriteable) throws IOException {
         String line = readableWriteable.readLine();
-
         List<String> rawRequestLine = Arrays.asList(line.split("\\s"));
 
         String method = rawRequestLine.get(0);

--- a/src/main/java/server/RequestParser.java
+++ b/src/main/java/server/RequestParser.java
@@ -20,7 +20,7 @@ public class RequestParser implements RequestParsable {
     public Request call(ReadableWriteable readableWriteable) throws IOException {
         RequestLineParser.RequestLine requestLine = requestLineParser.parse(readableWriteable);
         Map<String, String> headers = headersParser.parse(readableWriteable);
-        Integer contentLength = contentLengthParser.parse(headers);
+        int contentLength = contentLengthParser.parse(headers);
         String body = bodyParser.parse(readableWriteable, contentLength);
 
         return new Request(requestLine.method(), requestLine.path(), headers, body);

--- a/src/main/java/server/RequestParser.java
+++ b/src/main/java/server/RequestParser.java
@@ -7,16 +7,22 @@ public class RequestParser implements RequestParsable {
 
     private final RequestLineParser requestLineParser;
     private final HeadersParser headersParser;
+    private final BodyParser bodyParser;
+    private final ContentLengthParser contentLengthParser;
 
-    public RequestParser(RequestLineParser requestLineParser, HeadersParser headersParser) {
+    public RequestParser(RequestLineParser requestLineParser, HeadersParser headersParser, ContentLengthParser contentLengthParser, BodyParser bodyParser) {
         this.requestLineParser = requestLineParser;
         this.headersParser = headersParser;
+        this.contentLengthParser = contentLengthParser;
+        this.bodyParser = bodyParser;
     }
 
     public Request call(ReadableWriteable readableWriteable) throws IOException {
         RequestLineParser.RequestLine requestLine = requestLineParser.parse(readableWriteable);
         Map<String, String> headers = headersParser.parse(readableWriteable);
+        Integer contentLength = contentLengthParser.parse(headers);
+        String body = bodyParser.parse(readableWriteable, contentLength);
 
-        return new Request(requestLine.method(), requestLine.path(), headers);
+        return new Request(requestLine.method(), requestLine.path(), headers, body);
     }
 }

--- a/src/main/java/server/Response.java
+++ b/src/main/java/server/Response.java
@@ -1,4 +1,4 @@
 package server;
 
-public record Response(String protocol, String statusCode, String headers, String body) {
+public record Response(String protocol, String statusCode, java.util.Map<String, String> headers, String body) {
 }

--- a/src/main/java/server/ResponseWriter.java
+++ b/src/main/java/server/ResponseWriter.java
@@ -2,8 +2,7 @@ package server;
 
 public class ResponseWriter implements ResponseWriteable {
 
-    public ResponseWriter() {
-    }
+    String CRLF = "\r\n";
 
     public void call(ReadableWriteable readerWriter, Response response) {
         readerWriter.writeLine(format(response));
@@ -11,11 +10,18 @@ public class ResponseWriter implements ResponseWriteable {
 
     private String format(Response response) {
         String space = " ";
-        String CRLF = "\r\n";
+        String headers = headersAsString(response);
 
         return response.protocol() + space + response.statusCode() + CRLF +
-                response.headers() + CRLF +
-                CRLF +
+                headers + CRLF +
                 response.body();
+    }
+
+    private String headersAsString(Response response) {
+        StringBuilder headersAsString = new StringBuilder();
+        for (String key : response.headers().keySet()) {
+            headersAsString.append(key + ": " + response.headers().get(key) + CRLF);
+        }
+        return headersAsString.toString();
     }
 }

--- a/src/main/java/server/ResponseWriter.java
+++ b/src/main/java/server/ResponseWriter.java
@@ -9,19 +9,23 @@ public class ResponseWriter implements ResponseWriteable {
     }
 
     private String format(Response response) {
-        String space = " ";
-        String headers = headersAsString(response);
+        String statusLine = statusLine(response);
+        String headers = headers(response);
+        String body = response.body();
 
-        return response.protocol() + space + response.statusCode() + CRLF +
-                headers + CRLF +
-                response.body();
+        return statusLine + headers + CRLF + body;
     }
 
-    private String headersAsString(Response response) {
-        StringBuilder headersAsString = new StringBuilder();
+    private String statusLine(Response response) {
+        String space = " ";
+        return response.protocol() + space + response.statusCode() + CRLF;
+    }
+
+    private String headers(Response response) {
+        StringBuilder headers = new StringBuilder();
         for (String key : response.headers().keySet()) {
-            headersAsString.append(key + ": " + response.headers().get(key) + CRLF);
+            headers.append(key).append(": ").append(response.headers().get(key)).append(CRLF);
         }
-        return headersAsString.toString();
+        return headers.toString();
     }
 }

--- a/src/main/java/server/ResponseWriter.java
+++ b/src/main/java/server/ResponseWriter.java
@@ -2,7 +2,7 @@ package server;
 
 public class ResponseWriter implements ResponseWriteable {
 
-    String CRLF = "\r\n";
+    private final String CRLF = "\r\n";
 
     public void call(ReadableWriteable readerWriter, Response response) {
         readerWriter.writeLine(format(response));

--- a/src/main/java/server/RootPathHandler.java
+++ b/src/main/java/server/RootPathHandler.java
@@ -1,12 +1,14 @@
 package server;
 
+import java.util.Map;
+
 public class RootPathHandler implements Handler {
     @Override
     public Response call(Request request) {
         return new Response(
                 "HTTP/1.1",
                 "200 OK",
-                "Content-Length:0",
+                Map.of("Content-Length", "0"),
                 ""
         );
     }

--- a/src/main/java/server/SimpleGetHandler.java
+++ b/src/main/java/server/SimpleGetHandler.java
@@ -1,12 +1,14 @@
 package server;
 
+import java.util.Map;
+
 public class SimpleGetHandler implements Handler {
     @Override
     public Response call(Request request) {
         return new Response(
                 "HTTP/1.1",
                 "200 OK",
-                "Content-Length:0",
+                Map.of("Content-Length", "0"),
                 ""
         );
     }

--- a/src/main/java/server/SimpleGetWithBodyHandler.java
+++ b/src/main/java/server/SimpleGetWithBodyHandler.java
@@ -1,12 +1,14 @@
 package server;
 
+import java.util.Map;
+
 public class SimpleGetWithBodyHandler implements Handler {
     @Override
     public Response call(Request request) {
         return new Response(
                 "HTTP/1.1",
                 "200 OK",
-                "Content-Length:11",
+                Map.of("Content-Length", "11"),
                 "Hello world"
         );
     }

--- a/src/main/java/server/SimplePostHandler.java
+++ b/src/main/java/server/SimplePostHandler.java
@@ -1,0 +1,26 @@
+package server;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class SimplePostHandler implements Handler {
+
+    public Response call(Request request) {
+        return new Response(
+                "HTTP/1.1",
+                "200 OK",
+                responseHeaders(request),
+                request.body()
+        );
+    }
+
+    private Map<String, String> responseHeaders(Request request) {
+        Map<String, String> requestHeaders = request.headers();
+        Map<String, String> responseHeaders = new HashMap<>();
+
+        responseHeaders.put("Content-Length", requestHeaders.get("content-length"));
+        responseHeaders.put("Content-Type", requestHeaders.get("content-type"));
+
+        return responseHeaders;
+    }
+}

--- a/src/main/java/server/SimplePostHandler.java
+++ b/src/main/java/server/SimplePostHandler.java
@@ -6,21 +6,34 @@ import java.util.Map;
 public class SimplePostHandler implements Handler {
 
     public Response call(Request request) {
-        return new Response(
+        Response response = new Response(
                 "HTTP/1.1",
                 "200 OK",
                 responseHeaders(request),
                 request.body()
         );
+        return response;
     }
 
     private Map<String, String> responseHeaders(Request request) {
-        Map<String, String> requestHeaders = request.headers();
         Map<String, String> responseHeaders = new HashMap<>();
 
-        responseHeaders.put("Content-Length", requestHeaders.get("content-length"));
-        responseHeaders.put("Content-Type", requestHeaders.get("content-type"));
+        addContentLengthHeader(request, responseHeaders);
+        addContentTypeHeader(request, responseHeaders);
 
         return responseHeaders;
+    }
+
+    private void addContentLengthHeader(Request request, Map<String, String> responseHeaders) {
+        responseHeaders.put("Content-Length", String.valueOf(request.body().length()));
+    }
+
+    private void addContentTypeHeader(Request request, Map<String, String> responseHeaders) {
+        String contentType;
+        if ((contentType = request.headers().get("content-type")) != null) {
+            responseHeaders.put("Content-Type", contentType);
+        } else {
+            responseHeaders.put("Content-Type", "text/plain");
+        }
     }
 }

--- a/src/main/java/server/SimplePostHandler.java
+++ b/src/main/java/server/SimplePostHandler.java
@@ -6,13 +6,12 @@ import java.util.Map;
 public class SimplePostHandler implements Handler {
 
     public Response call(Request request) {
-        Response response = new Response(
+        return new Response(
                 "HTTP/1.1",
                 "200 OK",
                 responseHeaders(request),
                 request.body()
         );
-        return response;
     }
 
     private Map<String, String> responseHeaders(Request request) {

--- a/src/main/java/server/SocketReaderWriter.java
+++ b/src/main/java/server/SocketReaderWriter.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.net.Socket;
+import java.nio.charset.StandardCharsets;
 
 public class SocketReaderWriter implements ReadableWriteable {
     private final Socket socket;
@@ -14,9 +15,15 @@ public class SocketReaderWriter implements ReadableWriteable {
     public SocketReaderWriter(Socket socket) throws IOException {
         this.socket = socket;
         this.reader = new BufferedReader(
-                new InputStreamReader(this.socket.getInputStream())
+                new InputStreamReader(this.socket.getInputStream(), StandardCharsets.UTF_8)
         );
         this.writer = new PrintWriter(socket.getOutputStream(), true);
+    }
+
+    public String read(int contentLength) throws IOException {
+        char[] container = new char[contentLength];
+        reader.read(container, 0, contentLength);
+        return new String(container, 0, contentLength);
     }
 
     @Override

--- a/src/main/java/server/SocketReaderWriter.java
+++ b/src/main/java/server/SocketReaderWriter.java
@@ -22,6 +22,7 @@ public class SocketReaderWriter implements ReadableWriteable {
 
     public String read(int contentLength) throws IOException {
         char[] container = new char[contentLength];
+        //noinspection ResultOfMethodCallIgnored
         reader.read(container, 0, contentLength);
         return new String(container, 0, contentLength);
     }

--- a/src/test/java/server/BodyParserTest.java
+++ b/src/test/java/server/BodyParserTest.java
@@ -1,0 +1,36 @@
+package server;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class BodyParserTest {
+    @Test
+    void itParsesARequestBodyWithWhitespace() throws IOException {
+        ReadableWriteable readerWriter = new TestReaderWriter()
+                .send("Line 1: hi \r")
+                .send("Line 2. \n")
+                .send("Line 3. \r\n")
+                .send("Line 4.");
+
+        int contentLength = 38;
+
+        String body = new BodyParser().parse(readerWriter, contentLength);
+
+        assertEquals("Line 1: hi \rLine 2. \nLine 3. \r\nLine 4.", body);
+    }
+
+    @Test
+    void itParsesARequestBodyWithoutWhitespace() throws IOException {
+        ReadableWriteable readerWriter = new TestReaderWriter()
+                .send("Hello world");
+
+        int contentLength = 11;
+
+        String body = new BodyParser().parse(readerWriter, contentLength);
+
+        assertEquals("Hello world", body);
+    }
+}

--- a/src/test/java/server/ContentLengthParserTest.java
+++ b/src/test/java/server/ContentLengthParserTest.java
@@ -1,0 +1,39 @@
+package server;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ContentLengthParserTest {
+    @Test
+    void itReturnsContentLength() {
+        UUID apiKey = UUID.randomUUID();
+        Map<String, String> headers = Map.of(
+                "content-length", "42",
+                "content-type", "text/xml; charset=utf-8",
+                "api-key", apiKey.toString()
+        );
+
+        int contentLength = new ContentLengthParser()
+                .parse(headers);
+
+        assertEquals(42, contentLength);
+    }
+
+    @Test
+    void itReturnsNegativeOneIfNoContentLength() {
+        UUID apiKey = UUID.randomUUID();
+        Map<String, String> headers = Map.of(
+                "Content-Type", "text/xml; charset=utf-8",
+                "API-Key", apiKey.toString()
+        );
+
+        int contentLength = new ContentLengthParser()
+                .parse(headers);
+
+        assertEquals(-1, contentLength);
+    }
+}

--- a/src/test/java/server/HTTPServerSpecIntegrationTest.java
+++ b/src/test/java/server/HTTPServerSpecIntegrationTest.java
@@ -34,7 +34,7 @@ public class HTTPServerSpecIntegrationTest {
                 .call(readerWriter);
 
         List<String> expectedResponse = List.of(
-                "HTTP/1.1 200 OK\r\nContent-Length:11\r\n\r\nHello world"
+                "HTTP/1.1 200 OK\r\nContent-Length: 11\r\n\r\nHello world"
         );
 
         assertEquals(expectedResponse, readerWriter.received());
@@ -57,14 +57,14 @@ public class HTTPServerSpecIntegrationTest {
                 new ContentLengthParser(),
                 new BodyParser()
         );
-        Handler router = new HTTPServerSpecRouterFactory().create();
+        Handler router = HTTPServerSpecRouterFactory.create();
         ResponseWriteable responseWriter = new ResponseWriter();
 
         new HTTPServer(requestParser, router, responseWriter)
                 .call(readerWriter);
 
         List<String> expectedResponse = List.of(
-                "HTTP/1.1 404 Not Found\r\nContent-Length:0\r\n\r\n"
+                "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n"
         );
 
         assertEquals(expectedResponse, readerWriter.received());
@@ -87,7 +87,7 @@ public class HTTPServerSpecIntegrationTest {
                 new ContentLengthParser(),
                 new BodyParser()
         );
-        Handler router = new HTTPServerSpecRouterFactory().create();
+        Handler router = HTTPServerSpecRouterFactory.create();
         ResponseWriteable responseWriter = new ResponseWriter();
 
         new HTTPServer(requestParser, router, responseWriter)

--- a/src/test/java/server/HTTPServerSpecIntegrationTest.java
+++ b/src/test/java/server/HTTPServerSpecIntegrationTest.java
@@ -99,4 +99,36 @@ public class HTTPServerSpecIntegrationTest {
 
         assertEquals(expectedResponse, readerWriter.received());
     }
+
+    @Test
+    void itHandlesASimplePostRequest() throws IOException {
+        UUID apiKey = UUID.randomUUID();
+
+        TestReaderWriter readerWriter = new TestReaderWriter()
+                .send("POST /echo_body HTTP/1.1\r\n")
+                .send("Content-Length: 11\r\n")
+                .send("Content-Type: text\r\n")
+                .send(String.format("API-Key: %s\r\n", apiKey))
+                .send("\r\n")
+                .send("Hello World");
+
+
+        RequestParser requestParser = new RequestParser(
+                new RequestLineParser(),
+                new HeadersParser(),
+                new ContentLengthParser(),
+                new BodyParser()
+        );
+        Handler router = HTTPServerSpecRouterFactory.create();
+        ResponseWriteable responseWriter = new ResponseWriter();
+
+        new HTTPServer(requestParser, router, responseWriter)
+                .call(readerWriter);
+
+        List<String> expectedResponse = List.of(
+                "HTTP/1.1 200 OK\r\nContent-Length: 11\r\nContent-Type: text\r\n\r\nHello World"
+        );
+
+        assertEquals(expectedResponse, readerWriter.received());
+    }
 }

--- a/src/test/java/server/HTTPServerSpecIntegrationTest.java
+++ b/src/test/java/server/HTTPServerSpecIntegrationTest.java
@@ -21,7 +21,12 @@ public class HTTPServerSpecIntegrationTest {
                 .send(String.format("API-Key: %s\r\n", apiKey))
                 .send("\r\n");
 
-        RequestParser requestParser = new RequestParser(new RequestLineParser(), new HeadersParser());
+        RequestParser requestParser = new RequestParser(
+                new RequestLineParser(),
+                new HeadersParser(),
+                new ContentLengthParser(),
+                new BodyParser()
+        );
         Handler router = HTTPServerSpecRouterFactory.create();
         ResponseWriteable responseWriter = new ResponseWriter();
 
@@ -46,7 +51,12 @@ public class HTTPServerSpecIntegrationTest {
                 .send(String.format("API-Key: %s\r\n", apiKey))
                 .send("\r\n");
 
-        RequestParser requestParser = new RequestParser(new RequestLineParser(), new HeadersParser());
+        RequestParser requestParser = new RequestParser(
+                new RequestLineParser(),
+                new HeadersParser(),
+                new ContentLengthParser(),
+                new BodyParser()
+        );
         Handler router = new HTTPServerSpecRouterFactory().create();
         ResponseWriteable responseWriter = new ResponseWriter();
 
@@ -71,7 +81,12 @@ public class HTTPServerSpecIntegrationTest {
                 .send(String.format("API-Key: %s\r\n", apiKey))
                 .send("\r\n");
 
-        RequestParser requestParser = new RequestParser(new RequestLineParser(), new HeadersParser());
+        RequestParser requestParser = new RequestParser(
+                new RequestLineParser(),
+                new HeadersParser(),
+                new ContentLengthParser(),
+                new BodyParser()
+        );
         Handler router = new HTTPServerSpecRouterFactory().create();
         ResponseWriteable responseWriter = new ResponseWriter();
 

--- a/src/test/java/server/HTTPServerTest.java
+++ b/src/test/java/server/HTTPServerTest.java
@@ -30,14 +30,14 @@ public class HTTPServerTest {
             return new Response(
                     "HTTP/1.1",
                     "200 OK",
-                    "%s: %s".formatted(DATA_TO_THREAD_THROUGH_PIPELINE, cookie),
+                    Map.of(DATA_TO_THREAD_THROUGH_PIPELINE, cookie),
                     ""
             );
         };
 
         ResponseWriteable responseWriter = (socketReaderWriter, response) -> socketReaderWriter.writeLine(
                 "Valid response. %s: %s".formatted(DATA_TO_THREAD_THROUGH_PIPELINE,
-                        response.headers().split(":")[1].trim()));
+                        response.headers().get(DATA_TO_THREAD_THROUGH_PIPELINE)));
 
 
         new HTTPServer(requestParser, handler, responseWriter)

--- a/src/test/java/server/HTTPServerTest.java
+++ b/src/test/java/server/HTTPServerTest.java
@@ -20,7 +20,8 @@ public class HTTPServerTest {
                 new Request(
                         "GET",
                         "/",
-                        Map.of(DATA_TO_THREAD_THROUGH_PIPELINE, "42")
+                        Map.of(DATA_TO_THREAD_THROUGH_PIPELINE, "42"),
+                        ""
                 );
 
         Handler handler = request -> {

--- a/src/test/java/server/HeadersParserTest.java
+++ b/src/test/java/server/HeadersParserTest.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class HeadersParserTest {
+
     @Test
     void itParsesASingleHeader() throws IOException {
         ReadableWriteable readableWriteable = new TestReaderWriter()
@@ -18,7 +19,19 @@ public class HeadersParserTest {
         Map<String, String> header = new HeadersParser()
                 .parse(readableWriteable);
 
-        assertEquals(Map.of("Content-Length", "0"), header);
+        assertEquals(Map.of("content-length", "0"), header);
+    }
+
+    @Test
+    void headersAreCaseInsensitive() throws IOException {
+        ReadableWriteable readableWriteable = new TestReaderWriter()
+                .send("CONTENT-length: 0\r\n")
+                .send("\r\n");
+
+        Map<String, String> header = new HeadersParser()
+                .parse(readableWriteable);
+
+        assertEquals(Map.of("content-length", "0"), header);
     }
 
     @Test
@@ -34,9 +47,9 @@ public class HeadersParserTest {
                 .parse(readableWriteable);
 
         assertEquals(Map.of(
-                "Content-Length", "0",
-                "Content-Type", "text",
-                "API-Key", apiKey.toString()
+                "content-length", "0",
+                "content-type", "text",
+                "api-key", apiKey.toString()
         ), headers);
     }
 
@@ -49,7 +62,7 @@ public class HeadersParserTest {
         Map<String, String> header = new HeadersParser()
                 .parse(readableWriteable);
 
-        assertEquals(Map.of("Content-Length", "0"), header);
+        assertEquals(Map.of("content-length", "0"), header);
     }
 
     @Test
@@ -61,6 +74,6 @@ public class HeadersParserTest {
         Map<String, String> header = new HeadersParser()
                 .parse(readableWriteable);
 
-        assertEquals(Map.of("Content-Length", "0"), header);
+        assertEquals(Map.of("content-length", "0"), header);
     }
 }

--- a/src/test/java/server/RequestParserTest.java
+++ b/src/test/java/server/RequestParserTest.java
@@ -21,17 +21,62 @@ public class RequestParserTest {
                 .send("\r\n");
         RequestLineParser requestLineParser = new RequestLineParser();
         HeadersParser headersParser = new HeadersParser();
+        ContentLengthParser contentLengthParser = new ContentLengthParser();
+        BodyParser bodyParser = new BodyParser();
 
-        Request request = new RequestParser(requestLineParser, headersParser)
+        Request request = new RequestParser(
+                requestLineParser,
+                headersParser,
+                contentLengthParser,
+                bodyParser
+        )
                 .call(readableWriteable);
 
         Request expectedRequest = new Request(
                 "GET",
                 "/path/to/resource",
-                Map.of("Content-Length", "0",
-                        "Content-Type", "text",
-                        "API-Key", apiKey.toString()
-                )
+                Map.of("content-length", "0",
+                        "content-type", "text",
+                        "api-key", apiKey.toString().toLowerCase()
+                ),
+                ""
+        );
+
+        assertEquals(expectedRequest, request);
+    }
+
+    @Test
+    void itParsesARequestWithABody() throws IOException {
+        UUID apiKey = UUID.randomUUID();
+        ReadableWriteable readableWriteable = new TestReaderWriter()
+                .send("GET /path/to/resource HTTP/1.1\r\n")
+                .send("Content-Length: 37\r\n")
+                .send("Content-Type: text\r\n")
+                .send(String.format("API-Key: %s\r\n", apiKey))
+                .send("\r\n")
+                .send("Some body content. \n")
+                .send("More body content.");
+        RequestLineParser requestLineParser = new RequestLineParser();
+        HeadersParser headersParser = new HeadersParser();
+        ContentLengthParser contentLengthParser = new ContentLengthParser();
+        BodyParser bodyParser = new BodyParser();
+
+        Request request = new RequestParser(
+                requestLineParser,
+                headersParser,
+                contentLengthParser,
+                bodyParser
+        )
+                .call(readableWriteable);
+
+        Request expectedRequest = new Request(
+                "GET",
+                "/path/to/resource",
+                Map.of("content-length", "37",
+                        "content-type", "text",
+                        "api-key", apiKey.toString()
+                ),
+                "Some body content. \nMore body content."
         );
 
         assertEquals(expectedRequest, request);

--- a/src/test/java/server/ResponseWriterTest.java
+++ b/src/test/java/server/ResponseWriterTest.java
@@ -2,7 +2,9 @@ package server;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -13,7 +15,7 @@ public class ResponseWriterTest {
         Response response = new Response(
                 "HTTP/1.1",
                 "200 OK",
-                "Content-Length:0",
+                Map.of("Content-Length", "0"),
                 ""
         );
 
@@ -21,7 +23,7 @@ public class ResponseWriterTest {
                 .call(testReaderWriter, response);
 
         assertEquals(List.of(
-                "HTTP/1.1 200 OK\r\nContent-Length:0\r\n\r\n"
+                "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"
         ), testReaderWriter.received());
     }
 
@@ -31,14 +33,34 @@ public class ResponseWriterTest {
         Response response = new Response(
                 "HTTP/1.1",
                 "200 OK",
-                "Content-Length:11",
+                Map.of("Content-Length", "11"),
                 "Hello world"
         );
 
         new ResponseWriter()
                 .call(testReaderWriter, response);
 
-        assertEquals(List.of("HTTP/1.1 200 OK\r\nContent-Length:11\r\n\r\nHello world"), testReaderWriter.received());
+        assertEquals(List.of("HTTP/1.1 200 OK\r\nContent-Length: 11\r\n\r\nHello world"), testReaderWriter.received());
+    }
+
+    @Test
+    void itWritesA200ResponseWithMultipleHeadersAndABody() {
+        TestReaderWriter testReaderWriter = new TestReaderWriter();
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Content-Length", "11");
+        headers.put("Content-Type", "text");
+
+        Response response = new Response(
+                "HTTP/1.1",
+                "200 OK",
+                headers,
+                "Hello world"
+        );
+
+        new ResponseWriter()
+                .call(testReaderWriter, response);
+
+        assertEquals(List.of("HTTP/1.1 200 OK\r\nContent-Length: 11\r\nContent-Type: text\r\n\r\nHello world"), testReaderWriter.received());
     }
 
     @Test
@@ -47,7 +69,7 @@ public class ResponseWriterTest {
         Response response = new Response(
                 "HTTP/1.1",
                 "404 Not Found",
-                "Content-Length:0",
+                Map.of("Content-Length", "0"),
                 ""
         );
 
@@ -55,7 +77,7 @@ public class ResponseWriterTest {
                 .call(testReaderWriter, response);
 
         assertEquals(List.of(
-                "HTTP/1.1 404 Not Found\r\nContent-Length:0\r\n\r\n"
+                "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n"
         ), testReaderWriter.received());
     }
 }

--- a/src/test/java/server/RouterTest.java
+++ b/src/test/java/server/RouterTest.java
@@ -41,7 +41,8 @@ public class RouterTest {
         Request testRequest = new Request(
                 "HEAD",
                 "/get",
-                Map.of("Content-length", "0")
+                Map.of("Content-length", "0"),
+                ""
         );
 
         Response response = new Router(testRoutes, testNotFoundHandler)
@@ -62,7 +63,8 @@ public class RouterTest {
         Request testRequest = new Request(
                 "GET",
                 "/nonexistent_route",
-                Map.of("Content-Length", "0")
+                Map.of("Content-Length", "0"),
+                ""
         );
 
         Response response = new Router(testRoutes, testNotFoundHandler)

--- a/src/test/java/server/RouterTest.java
+++ b/src/test/java/server/RouterTest.java
@@ -29,7 +29,7 @@ public class RouterTest {
             )
     );
 
-    Handler testNotFoundHandler = request -> new Response(
+    private final Handler testNotFoundHandler = request -> new Response(
             "protocol",
             "404 Not Found",
             Map.of("Route", "not found"),

--- a/src/test/java/server/RouterTest.java
+++ b/src/test/java/server/RouterTest.java
@@ -12,19 +12,19 @@ public class RouterTest {
             "GET /get", request -> new Response(
                     "protocol",
                     "statusCode",
-                    "Route: GET /get",
+                    Map.of("Route", "GET /get"),
                     ""
             ),
             "HEAD /get", request -> new Response(
                     "protocol",
                     "statusCode",
-                    "Route: HEAD /get",
+                    Map.of("Route", "HEAD /get"),
                     ""
             ),
             "HEAD /head", request -> new Response(
                     "protocol",
                     "statusCode",
-                    "Route: HEAD /head",
+                    Map.of("Route", "HEAD /head"),
                     ""
             )
     );
@@ -32,7 +32,7 @@ public class RouterTest {
     Handler testNotFoundHandler = request -> new Response(
             "protocol",
             "404 Not Found",
-            "Route: not found",
+            Map.of("Route", "not found"),
             ""
     );
 
@@ -51,7 +51,7 @@ public class RouterTest {
         Response expectedResponse = new Response(
                 "protocol",
                 "statusCode",
-                "Route: HEAD /get",
+                Map.of("Route", "HEAD /get"),
                 ""
         );
 
@@ -73,7 +73,7 @@ public class RouterTest {
         Response expectedResponse = new Response(
                 "protocol",
                 "404 Not Found",
-                "Route: not found",
+                Map.of("Route", "not found"),
                 ""
         );
         assertEquals(expectedResponse, response);

--- a/src/test/java/server/ServerTest.java
+++ b/src/test/java/server/ServerTest.java
@@ -96,6 +96,11 @@ public class ServerTest {
         }
 
         @Override
+        public String read(int contentLength) {
+            return null;
+        }
+
+        @Override
         public void close() {
             events.add("Connection closed");
         }

--- a/src/test/java/server/SimplePostHandlerTest.java
+++ b/src/test/java/server/SimplePostHandlerTest.java
@@ -1,0 +1,34 @@
+package server;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class SimplePostHandlerTest {
+    @Test
+    void itEchoesTheBody() {
+        Request request = new Request(
+                "POST",
+                "/echo_body",
+                Map.of("content-length", "11",
+                        "content-type", "text"
+                ),
+                "Hello World"
+        );
+
+        Response response = new SimplePostHandler().call(request);
+
+        Response expectedResponse = new Response(
+                "HTTP/1.1",
+                "200 OK",
+                Map.of("Content-Length", "11",
+                        "Content-Type", "text"
+                ),
+                "Hello World"
+        );
+
+        assertEquals(expectedResponse, response);
+    }
+}

--- a/src/test/java/server/SimplePostHandlerTest.java
+++ b/src/test/java/server/SimplePostHandlerTest.java
@@ -13,18 +13,18 @@ public class SimplePostHandlerTest {
                 "POST",
                 "/echo_body",
                 Map.of("content-length", "11",
-                        "content-type", "text"
+                        "content-type", "text/plain"
                 ),
                 "Hello World"
         );
 
         Response response = new SimplePostHandler().call(request);
-
+        
         Response expectedResponse = new Response(
                 "HTTP/1.1",
                 "200 OK",
                 Map.of("Content-Length", "11",
-                        "Content-Type", "text"
+                        "Content-Type", "text/plain"
                 ),
                 "Hello World"
         );

--- a/src/test/java/server/SocketReaderWriterTest.java
+++ b/src/test/java/server/SocketReaderWriterTest.java
@@ -10,6 +10,18 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class SocketReaderWriterTest {
 
     @Test
+    void itReadsTextUpToAGivenLength() throws IOException {
+        String input = "Hello, world! 😀";
+        TestSocket testSocket = new TestSocket(String.format(input));
+        ReadableWriteable socketReaderWriter = new SocketReaderWriter(testSocket);
+        int contentLength = input.length();
+
+        String message = socketReaderWriter.read(contentLength);
+
+        assertEquals("Hello, world! 😀", message);
+    }
+
+    @Test
     void readsALineOfText() throws IOException {
         TestSocket testSocket = new TestSocket("Hello\n");
         ReadableWriteable socketReaderWriter = new SocketReaderWriter(testSocket);

--- a/src/test/java/server/TestReaderWriter.java
+++ b/src/test/java/server/TestReaderWriter.java
@@ -17,6 +17,15 @@ public class TestReaderWriter implements ReadableWriteable {
     }
 
     @Override
+    public String read(int contentLength) {
+        String body = "";
+        while (body.length() < contentLength) {
+            body += this.readLine();
+        }
+        return body;
+    }
+
+    @Override
     public void writeLine(String message) {
         written.add(message);
     }
@@ -34,5 +43,4 @@ public class TestReaderWriter implements ReadableWriteable {
     public List<String> received() {
         return written;
     }
-
 }

--- a/src/test/java/server/TestReaderWriter.java
+++ b/src/test/java/server/TestReaderWriter.java
@@ -18,11 +18,11 @@ public class TestReaderWriter implements ReadableWriteable {
 
     @Override
     public String read(int contentLength) {
-        String body = "";
+        StringBuilder body = new StringBuilder();
         while (body.length() < contentLength) {
-            body += this.readLine();
+            body.append(this.readLine());
         }
-        return body;
+        return body.toString();
     }
 
     @Override


### PR DESCRIPTION
Changes:

- Making a POST request to /echo_body results in a response with code 200 OK and the original body content.

Questions:

I'm still looking for the most robust way to convert bytes to a string in `SocketReaderWriter`'s `read` method. I specified that the `InputStreamReader` (the first step which converts bytes to characters) should use UTF-8. When reading character by character, `BufferedReader`'s `read` method breaks when it's given a multibyte character (ex. emoji, Chinese character, Greek letter). But it's able to handle multibyte characters when it reads into a `char[]`. 

I've been looking at reading byte by byte and the converting into a string using some other method, but I'm not sure whether calling `.toString()` on a `byte[]` would be more robust than using `BufferedReader`. 